### PR TITLE
Coloring multiple regions of interest

### DIFF
--- a/R/manhattanly.R
+++ b/R/manhattanly.R
@@ -373,12 +373,12 @@ manhattanly.manhattanr <- function(x,
     }
   }
   
-  # Highlight multiple SNP sets
+  # Color multiple regions of interest
   if (!is.na(snpName)) {
     if (!is.null(snpSets)) {
       for(snpSetIndex in 1:length(snpSets))
       {
-        snpSet = snpSets[snpSetIndex]
+        snpSet = unlist(snpSets[snpSetIndex])
         snpSetColor = snpSetColors[snpSetIndex]
 
         if (any(!(snpSet %in% d[[snpName]]))) warning("You're trying to highlight SNPs that don't exist in your results.")

--- a/R/manhattanly.R
+++ b/R/manhattanly.R
@@ -85,6 +85,8 @@ manhattanly <- function(x,
                         highlight_color = "#00FF00",
                         showlegend = FALSE,
                         showgrid = FALSE,
+                        snpSets = NULL,
+                        snpSetColors = NULL,  
                         xlab = NULL,
                         ylab = "-log10(p)",
                         title = "Manhattan Plot", ...) {
@@ -367,6 +369,24 @@ manhattanly.manhattanr <- function(x,
                        marker = list(color = highlight_color,
                                      size = point_size),
                        name = "of interest")
+
+      for(snpSetIndex in 1:length(snpSets))
+      {
+        snpSet = snpSets[snpSetIndex]
+        snpSetColor = snpSetColors[snpSetIndex]
+        snpSet.highlight <- d[which(d[[snpName]] %in% snpSet), ]
+        p %<>% plotly::add_trace(x = snpSet.highlight$pos,
+                         y = snpSet.highlight$logp,
+                         type = "scatter",
+                         mode = "markers",
+                         evaluate = TRUE,
+                         text = snpSet.highlight[[snpName]],
+                         showlegend = showlegend,
+                         marker = list(color = snpSetColor,
+                                       size = point_size),
+                         name = "of interest")
+      }
+
     }
   }
   p

--- a/R/manhattanly.R
+++ b/R/manhattanly.R
@@ -86,7 +86,7 @@ manhattanly <- function(x,
                         showlegend = FALSE,
                         showgrid = FALSE,
                         snpSets = NULL,
-                        snpSetColors = NULL,  
+                        snpSetColors = NULL,
                         xlab = NULL,
                         ylab = "-log10(p)",
                         title = "Manhattan Plot", ...) {
@@ -370,10 +370,19 @@ manhattanly.manhattanr <- function(x,
                                      size = point_size),
                        name = "of interest")
 
+    }
+  }
+  
+  # Highlight multiple SNP sets
+  if (!is.na(snpName)) {
+    if (!is.null(snpSets)) {
       for(snpSetIndex in 1:length(snpSets))
       {
         snpSet = snpSets[snpSetIndex]
         snpSetColor = snpSetColors[snpSetIndex]
+
+        if (any(!(snpSet %in% d[[snpName]]))) warning("You're trying to highlight SNPs that don't exist in your results.")
+
         snpSet.highlight <- d[which(d[[snpName]] %in% snpSet), ]
         p %<>% plotly::add_trace(x = snpSet.highlight$pos,
                          y = snpSet.highlight$logp,
@@ -385,9 +394,9 @@ manhattanly.manhattanr <- function(x,
                          marker = list(color = snpSetColor,
                                        size = point_size),
                          name = "of interest")
-      }
 
-    }
+      }
+    } 
   }
   p
 }

--- a/man/manhattanly.Rd
+++ b/man/manhattanly.Rd
@@ -63,6 +63,12 @@ means that nothing is highlighted.}
 
 \item{showgrid}{Should gridlines be shown. Default is \code{FALSE}.}
 
+\item{snpSets}{List of character vectors of SNPs in the dataset to be highlighted.
+ Default is \code{NULL}.}
+
+\item{snpSetColors}{Corresponding list of colors to be used to highlight snpSets.
+Default is \code{NULL}.}
+
 \item{xlab}{X-axis label. Default is \code{NULL} which means that the label
 is automatically determined by the \code{\link{manhattanr}} function.
 Specify here to overwrite the default.}

--- a/vignettes/manhattanly.Rmd
+++ b/vignettes/manhattanly.Rmd
@@ -126,6 +126,20 @@ manhattanly(subset(HapMap, CHR %in% 4:7), snp = "SNP", gene = "GENE", highlight 
 ***************
 ***************
 
+## Coloring Multiple Regions of Interest
+
+We can color multiple regions of interest using the `snpSets` and `snpSetColors` arguments. For example, to color the first thousand SNPs sea green and the last thousand hot pink, we pass the following `snpSets` and `snpSetColors` arguments (note that these SNPs need to be present in the `"SNP"` column of your data):
+
+```{r, eval = TRUE}
+snpSetOne = head(HapMap,1000)$SNP
+snpSetTwo = tail(HapMap,1000)$SNP
+snpSets = list("one" = snpSetOne, "two" = snpSetTwo)
+snpSetColors = c("#18A3AC", "#EC1848")
+manhattanly(HapMap, snp = "SNP", gene = "GENE", snpSets = snpSets, snpSetColors = snpSetColors)
+```
+
+***************
+***************
 
 
 ## More annotations


### PR DESCRIPTION
Added functionality, documentation, and vignette for coloring an indefinite number of regions on the manhattan plot.
